### PR TITLE
exposes POST `api/v1/users` endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "lockbox", "~> 0.6.8"
+
+gem "blind_index", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,11 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    argon2-kdf (0.1.7)
     bcrypt (3.1.16)
+    blind_index (2.3.0)
+      activesupport (>= 5.2)
+      argon2-kdf (>= 0.1.1)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -92,6 +96,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lockbox (0.6.8)
     loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -204,6 +209,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
+  blind_index (~> 2.3)
   bootsnap (>= 1.1.0)
   byebug
   capybara
@@ -213,6 +219,7 @@ DEPENDENCIES
   figaro
   jsonapi-serializer
   listen (>= 3.0.5, < 3.2)
+  lockbox (~> 0.6.8)
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,33 @@
+class Api::V1::UsersController < ApplicationController
+  # before_action :set_private_api_key
+
+  def create
+    user = User.new(user_params)
+
+    if params[:password] != params[:password_confirmation] || !params[:password] && !params[:password_confirmation]
+      render json: {error: "Passwords do not match or field is missing, please try again"}, status: 400
+    elsif !params[:password] || !params[:email] || !params[:password_confirmation]
+      render json: {error: "Missing field(s), please try again"}, status: 400
+    else params[:password] == params[:password_confirmation] && params[:email] != nil
+      validate_email(user)
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+
+  def validate_email(new_user)
+    if new_user.save
+      render json: UsersSerializer.new(new_user), status: 201
+    else
+      render json: {error: "Email has already been taken, please try again"}, status: 400
+    end
+  end
+
+  # def set_private_api_key
+  #   user.private_api_key = SecureRandom.urlsafe_base64(24)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,7 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  validates_presence_of :email
+  validates_uniqueness_of :email, case_sensitive: false
+  validates_presence_of :api_key
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,20 @@
 class User < ApplicationRecord
   has_secure_password
 
+  validates_presence_of :password_digest
   validates_presence_of :email
   validates_uniqueness_of :email, case_sensitive: false
-  validates_presence_of :api_key
+
+  encrypts :private_api_key, key: Lockbox.attribute_key(table: "users", attribute: "private_api_key_ciphertext")
+  blind_index :private_api_key, key: ENV["blind_index_master_key"]
+  before_create :set_private_api_key
+
+  validates_presence_of :private_api_key, allow_blank: true
+  validates_uniqueness_of :private_api_key, allow_blank: true
+
+  private
+
+  def set_private_api_key
+    self.private_api_key = SecureRandom.urlsafe_base64(24) if self.private_api_key.nil?
+  end
 end

--- a/app/serializers/users_serializer.rb
+++ b/app/serializers/users_serializer.rb
@@ -1,0 +1,6 @@
+class UsersSerializer
+  include JSONAPI::Serializer
+
+  attributes :email, :private_api_key
+
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resource :forecast, controller: 'forecasts', action: 'index'
       resources :backgrounds, controller: 'backgrounds', action: 'index'
+      resources :users, only: [:create]
     end
   end
 end

--- a/db/migrate/20220306044844_create_users.rb
+++ b/db/migrate/20220306044844_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :api_key
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220306044844_create_users.rb
+++ b/db/migrate/20220306044844_create_users.rb
@@ -2,7 +2,6 @@ class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       t.string :email
-      t.string :api_key
 
       t.timestamps
     end

--- a/db/migrate/20220306045358_add_password_digest_to_users.rb
+++ b/db/migrate/20220306045358_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/migrate/20220306210405_add_private_api_key_ciphertext_to_users.rb
+++ b/db/migrate/20220306210405_add_private_api_key_ciphertext_to_users.rb
@@ -1,0 +1,8 @@
+class AddPrivateApiKeyCiphertextToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :private_api_key_ciphertext, :string
+
+    add_column :users, :private_api_key_bidx, :string
+    add_index :users, :private_api_key_bidx, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_03_06_045358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "api_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "password_digest"
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_06_045358) do
+ActiveRecord::Schema.define(version: 2022_03_06_210405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
     t.string "email"
-    t.string "api_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "private_api_key_ciphertext"
+    t.string "private_api_key_bidx"
+    t.index ["private_api_key_bidx"], name: "index_users_on_private_api_key_bidx", unique: true
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { "MyString" }
+    api_key { "MyString" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email).case_insensitive }
+  end
+
+  describe 'test of password validations' do
+    it 'encrypts password' do
+      test_user = User.create(email: 'sierra@test.com', password: 'test12', password_confirmation: 'test12')
+      expect(test_user).to_not have_attribute(:password)
+      expect(test_user).to_not have_attribute(:password_confirmation)
+      expect(test_user.password_digest).to_not eq('test12')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,13 +2,16 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'validations' do
+    it { should have_secure_password }
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email).case_insensitive }
+    # it { should validate_presence_of(:private_api_key).allow_blank }
+    # it { should validate_uniqueness_of(:private_api_key).allow_blank }
   end
 
   describe 'test of password validations' do
     it 'encrypts password' do
-      test_user = User.create(email: 'sierra@test.com', password: 'test12', password_confirmation: 'test12')
+      test_user = User.create!(email: 'sierra@test.com', password: 'test12', password_confirmation: 'test12')
       expect(test_user).to_not have_attribute(:password)
       expect(test_user).to_not have_attribute(:password_confirmation)
       expect(test_user.password_digest).to_not eq('test12')

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'Users API' do
+  describe 'user registration' do
+    describe 'happy path' do
+      it 'creates a user and generates unique api key associated with user' do
+        user_params = {
+                    email: 'test@email.com',
+                    password: 'password',
+                    password_confirmation: 'password'
+                    }
+        headers = {"CONTENT_TYPE" => "application/json"}
+        post "/api/v1/users", headers: headers, params: JSON.generate(user_params)
+        created_user = JSON.parse(response.body, symbolize_names: true)
+  
+        expect(response.status).to eq(201)
+        expect(created_user).to have_key(:data)
+        expect(created_user[:data][:type]).to eq("users")
+        expect(created_user[:data][:attributes]).to have_key(:email)
+        expect(created_user[:data][:attributes]).to have_key(:private_api_key)
+
+      end
+    end
+
+    describe 'sad path' do
+      describe 'passwords do not match' do
+        it 'returns a 400 status and description of what went wrong' do
+          user_params = {
+                      email: 'test@email.com',
+                      password: 'password',
+                      password_confirmation: 'better_password'
+                      }
+          headers = {"CONTENT_TYPE" => "application/json"}
+          post "/api/v1/users", headers: headers, params: JSON.generate(user_params)
+          no_user = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response.status).to eq(400)
+          expect(no_user).to have_key(:error)
+          expect(no_user[:error]).to eq("Passwords do not match or field is missing, please try again")
+        end
+      end
+
+      describe 'email has already been used' do
+        it 'returns a 400 status and description of what went wrong' do
+          other_user = User.create!(email: 'test@email.com', password: 'mine', password_confirmation: 'mine')
+          user_params = {
+                      email: 'test@email.com',
+                      password: 'password',
+                      password_confirmation: 'password'
+                      }
+          headers = {"CONTENT_TYPE" => "application/json"}
+          post "/api/v1/users", headers: headers, params: JSON.generate(user_params)
+
+          no_user = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response.status).to eq(400)
+          expect(no_user).to have_key(:error)
+          expect(no_user[:error]).to eq("Email has already been taken, please try again")
+        end
+      end
+
+      describe 'field missing' do
+        it 'returns a 400 status if password_confirmation is missing' do
+          user_params = ({
+                      email: 'test@email.com',
+                      password: 'password',
+                      })
+          headers = {"CONTENT_TYPE" => "application/json"}
+          post "/api/v1/users", headers: headers, params: JSON.generate(user_params)
+
+          no_user = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response.status).to eq(400)
+          expect(no_user).to have_key(:error)
+          expect(no_user[:error]).to eq("Passwords do not match or field is missing, please try again")
+        end
+
+        it 'returns a 400 status if password is missing' do
+          user_params = ({
+                      email: 'test@email.com',
+                      password_confirmation: 'password',
+                      })
+          headers = {"CONTENT_TYPE" => "application/json"}
+          post "/api/v1/users", headers: headers, params: JSON.generate(user_params)
+
+          no_user = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response.status).to eq(400)
+          expect(no_user).to have_key(:error)
+          expect(no_user[:error]).to eq("Passwords do not match or field is missing, please try again")
+        end
+
+        it 'returns a 400 status if email is missing' do
+          user_params = ({
+                      password: 'password',
+                      password_confirmation: 'password',
+                      })
+          headers = {"CONTENT_TYPE" => "application/json"}
+          post "/api/v1/users", headers: headers, params: JSON.generate(user_params)
+
+          no_user = JSON.parse(response.body, symbolize_names: true)
+
+          expect(response.status).to eq(400)
+          expect(no_user).to have_key(:error)
+          expect(no_user[:error]).to eq("Missing field(s), please try again")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Checklist
- [x] Tests written where required
- [x] All tests passing
- [x] Unused code/prys/etc deleted
- SimpleCov at 100%

## Changes Made
- Added **Lockbox** and **blind_index** gems to encrypt and set an api key for newly registered users. Later, can be used to match user's api key with the api key sent in their requests within the application.
- Within the `user.rb` model, a `before_create :set_private_api_key` exists to set this private api key as part of the user creation/serialization process.
- Thorough happy/sad path testing for the POST `api/v1/users` request in the `users_request_spec.rb`

## Special notes
Commented out validation tests in user model, still trying to figure out validation of users api key since it is not passed in as part of the registration, but rather generated upon the request being made. Just need to figure out how to test that this field is blank, but not after the user is created.
